### PR TITLE
disk: efi_loader: Improve disk image detection in efi_bootmgr

### DIFF
--- a/disk/part.c
+++ b/disk/part.c
@@ -63,7 +63,7 @@ static struct part_driver *part_driver_get_type(int part_type)
  * @dev_desc: Device descriptor
  * Return: Driver found, or NULL if none
  */
-static struct part_driver *part_driver_lookup_type(struct blk_desc *desc)
+struct part_driver *part_driver_lookup_type(struct blk_desc *desc)
 {
 	struct part_driver *drv =
 		ll_entry_start(struct part_driver, part_driver);

--- a/include/part.h
+++ b/include/part.h
@@ -727,6 +727,24 @@ int part_get_type_by_name(const char *name);
  */
 int part_get_bootable(struct blk_desc *desc);
 
+/**
+ * part_driver_lookup_type() - Look up the partition driver for a blk device
+ *
+ * If @desc->part_type is PART_TYPE_UNKNOWN, this checks each partition driver
+ * against the blk device to see if there is a valid partition table acceptable
+ * to that driver.
+ *
+ * If @desc->part_type is already set, it just returns the driver for that
+ * type, without testing if the driver can find a valid partition on the
+ * descriptor.
+ *
+ * On success it updates @desc->part_type if set to PART_TYPE_UNKNOWN on entry
+ *
+ * @desc: Device descriptor
+ * Return: Driver found, or NULL if none
+ */
+struct part_driver *part_driver_lookup_type(struct blk_desc *desc);
+
 #else
 static inline int part_driver_get_count(void)
 { return 0; }


### PR DESCRIPTION
Enhances the process for identifying disk images within the EFI boot manager. Utilize part_driver_lookup_type() to verify the validity of a downloaded file as a disk image, rather than depending on file extensions.

part_driver_lookup_type() is now used in the prepare_loaded_image() function in the EFI boot manager to detect partitions on a block device created from a downloaded image. This allows the boot manager to boot from any disk image that can be recognized by a partition driver, not just ISO and IMG images.

Update prepare_loaded_image() to create the ramdisk block device internally, obtain the blk_desc and use part_driver_lookup_type() to detect a valid partition table.

In try_load_from_uri_path(), try prepare_loaded_image() first to detect disk images, and fall back to PE-COFF detection only if that fails.

Include part.h in the EFI loader and export part_driver_lookup_type and add its prototype and documentation in include/part.h. This makes the partition-driver lookup available to other code paths that need to detect partition tables on a block descriptor.